### PR TITLE
fix: import VideoFileClip Error

### DIFF
--- a/videoCut.py
+++ b/videoCut.py
@@ -6,7 +6,7 @@ import cv2
 from sentence_transformers import util
 from PIL import Image
 from skimage import metrics
-from moviepy.editor import VideoFileClip
+from moviepy import VideoFileClip
 import comfy.model_management as model_management
 
 def SSIM(imgPath0, imgPath1):


### PR DESCRIPTION
MoviePy 2.x 后不支持 `from moviepy.editor import VideoFileClip` 的方式引入了
目前修改为 `from moviepy import VideoFileClip` 方式引入